### PR TITLE
improvement: switching from pip to uv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,15 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: 3.11
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+          enable-cache: true
+      - run: uv venv
+      - run: uv pip install --python .venv/bin/python -r docs/requirements.txt
+      - run: uv run --python .venv/bin/python mkdocs gh-deploy --force

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,11 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Ruff
-        run: pip install ruff
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Ruff lint
-        run: ruff check .
+        run: uvx ruff check .
 
       - name: Ruff format check
-        run: ruff format . --check
+        run: uvx ruff format . --check

--- a/README.md
+++ b/README.md
@@ -78,8 +78,15 @@ An overview of the provided datasets is available in the [documentation](https:/
 ## Installation
 
 The installation of the package is simple by
+
 ```
-pip install wildlife-datasets
+uv add wildlife-datasets
+```
+
+Or, if you already have a virtual environment:
+
+```
+uv pip install wildlife-datasets
 ```
 
 ## Adding new datasets

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,5 +3,11 @@
 The installation of the package is simple by
 
 ```
-pip install wildlife-datasets
+uv add wildlife-datasets
+```
+
+Or, if you already have a virtual environment:
+
+```
+uv pip install wildlife-datasets
 ```


### PR DESCRIPTION
This PR updates the repository’s Python tooling workflow to use `uv` instead of `pip` in CI and installation docs.

Given many requirements, UV allows much faster installation (~100 times) than a traditional pip-based setup, reduces tool sprawl by handling virtual environments, installs, and command execution in one place, and simplifies CI. In particular, using uvx ruff removes the need for a separate Ruff install step, and using uv venv plus uv pip makes the docs deploy workflow more consistent.

Changes:
- replace the docs deploy workflow’s pip install step with uv
- replace pip install ruff with uvx ruff in CI
- update README and installation docs to recommend uv